### PR TITLE
fix repo url parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v1.3.1](https://github.com/containeroo/helminator/tree/v1.3.1) (2020-07-07)
+
+[All Commits](https://github.com/containeroo/helminator/compare/v1.3.0...v1.3.1)
+
+**Bug fixes:**
+
+- Helm repo urls with a trailing slash are now parsed correctly (#21)
+
 ## [v1.3.0](https://github.com/containeroo/helminator/tree/v1.3.0) (2020-06-26)
 
 [All Commits](https://github.com/containeroo/helminator/compare/v1.2.1...v1.3.0)

--- a/helminator.py
+++ b/helminator.py
@@ -148,7 +148,7 @@ def get_ansible_helm(path, enable_prereleases=False):
             if not any(repo for repo in ansible_chart_repos if
                        repo['name'] == task['community.kubernetes.helm_repository']['name']):
                 repo_name = task['community.kubernetes.helm_repository']['name']
-                repo_url = task['community.kubernetes.helm_repository']['repo_url']
+                repo_url = task['community.kubernetes.helm_repository']['repo_url'].rstrip('/')
                 repo = {
                     'name': repo_name,
                     'url': repo_url
@@ -176,7 +176,7 @@ def get_chart_updates(enable_prereleases=False):
 
         logging.debug(f"processing helm repository '{ansible_chart_repo['url']}'")
         try:
-            helm_chart_url = f"{ansible_chart_repo['url'].rstrip('/')}/index.yaml"
+            helm_chart_url = f"{ansible_chart_repo['url']}/index.yaml"
             repo_response = requests.get(url=helm_chart_url)
         except Exception as e:
             logging.error(f"unable to fetch helm repository '{helm_chart_url}'. {str(e)}")

--- a/helminator.py
+++ b/helminator.py
@@ -176,7 +176,7 @@ def get_chart_updates(enable_prereleases=False):
 
         logging.debug(f"processing helm repository '{ansible_chart_repo['url']}'")
         try:
-            helm_chart_url = f"{ansible_chart_repo['url']}/index.yaml"
+            helm_chart_url = f"{ansible_chart_repo['url'].rstrip('/')}/index.yaml"
             repo_response = requests.get(url=helm_chart_url)
         except Exception as e:
             logging.error(f"unable to fetch helm repository '{helm_chart_url}'. {str(e)}")


### PR DESCRIPTION
add rstrip('/') to url to make sure it gets parsed correctly